### PR TITLE
Add freeze panes support (closes #4)

### DIFF
--- a/python/opensheet_core/_native.pyi
+++ b/python/opensheet_core/_native.pyi
@@ -16,6 +16,7 @@ def read_xlsx(path: str) -> list[dict[str, Any]]:
       - ``"merges"``: list of merged cell range strings (e.g. ``"A1:C1"``)
       - ``"column_widths"``: dict mapping 0-based column index to width in character units
       - ``"row_heights"``: dict mapping 0-based row index to height in points
+      - ``"freeze_pane"``: tuple of (rows_frozen, cols_frozen) or None
     """
     ...
 
@@ -56,6 +57,12 @@ class XlsxWriter:
         ...
     def merge_cells(self, range: str) -> None:
         """Merge a range of cells (e.g. ``"A1:C1"``)."""
+        ...
+    def freeze_panes(self, row: int = 0, col: int = 0) -> None:
+        """Freeze the top ``row`` rows and left ``col`` columns.
+
+        Must be called after ``add_sheet()`` but before any ``write_row()`` calls on that sheet.
+        """
         ...
     def set_column_width(self, column: str | int, width: float) -> None:
         """Set the width of a column in character units.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,6 +192,17 @@ fn read_xlsx(py: Python<'_>, path: &str) -> PyResult<Py<PyAny>> {
         }
         dict.set_item("row_heights", row_heights_dict)?;
 
+        // Freeze pane: (rows_frozen, cols_frozen) or None
+        match sheet.freeze_pane {
+            Some((row, col)) => {
+                let tuple = (row, col);
+                dict.set_item("freeze_pane", tuple)?;
+            }
+            None => {
+                dict.set_item("freeze_pane", py.None())?;
+            }
+        }
+
         result.append(dict)?;
     }
 
@@ -332,6 +343,19 @@ impl XlsxWriter {
             .as_mut()
             .ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err("Writer is already closed"))?;
         w.merge_cells(range)?;
+        Ok(())
+    }
+
+    /// Freeze the top `row` rows and left `col` columns.
+    ///
+    /// Must be called after add_sheet() but before any write_row() calls on that sheet.
+    #[pyo3(signature = (row=0, col=0))]
+    fn freeze_panes(&mut self, row: u32, col: u32) -> PyResult<()> {
+        let w = self
+            .inner
+            .as_mut()
+            .ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err("Writer is already closed"))?;
+        w.freeze_panes(row, col)?;
         Ok(())
     }
 

--- a/src/reader/xlsx.rs
+++ b/src/reader/xlsx.rs
@@ -83,6 +83,7 @@ pub fn read_xlsx<R: Read + Seek>(reader: R) -> Result<Vec<Sheet>, XlsxError> {
             merges: data.merges,
             column_widths: data.column_widths,
             row_heights: data.row_heights,
+            freeze_pane: data.freeze_pane,
         });
     }
 
@@ -392,12 +393,13 @@ fn parse_cell_ref(cell_ref: &str) -> (usize, usize) {
     (row.saturating_sub(1), col)
 }
 
-/// Parsed worksheet data: rows, merge ranges, column widths, and row heights.
+/// Parsed worksheet data: rows, merge ranges, column widths, row heights, and freeze pane.
 struct WorksheetData {
     rows: Vec<Vec<CellValue>>,
     merges: Vec<String>,
     column_widths: HashMap<u32, f64>,
     row_heights: HashMap<u32, f64>,
+    freeze_pane: Option<(u32, u32)>,
 }
 
 /// Parse a single worksheet XML file and return rows of cell values and merge ranges.
@@ -427,11 +429,36 @@ fn parse_worksheet<R: Read + Seek>(
     let mut column_widths: HashMap<u32, f64> = HashMap::new();
     let mut row_heights: HashMap<u32, f64> = HashMap::new();
     let mut in_cols = false;
+    let mut freeze_pane: Option<(u32, u32)> = None;
 
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Start(ref e)) => {
                 match e.name().as_ref() {
+                    b"pane" => {
+                        let mut y_split: u32 = 0;
+                        let mut x_split: u32 = 0;
+                        let mut state = String::new();
+                        for attr in e.attributes().flatten() {
+                            match attr.key.as_ref() {
+                                b"ySplit" => {
+                                    y_split =
+                                        String::from_utf8_lossy(&attr.value).parse().unwrap_or(0);
+                                }
+                                b"xSplit" => {
+                                    x_split =
+                                        String::from_utf8_lossy(&attr.value).parse().unwrap_or(0);
+                                }
+                                b"state" => {
+                                    state = String::from_utf8_lossy(&attr.value).to_string();
+                                }
+                                _ => {}
+                            }
+                        }
+                        if state == "frozen" && (y_split > 0 || x_split > 0) {
+                            freeze_pane = Some((y_split, x_split));
+                        }
+                    }
                     b"cols" => {
                         in_cols = true;
                     }
@@ -603,6 +630,28 @@ fn parse_worksheet<R: Read + Seek>(
                     _ => {}
                 }
             }
+            Ok(Event::Empty(ref e)) if e.name().as_ref() == b"pane" => {
+                let mut y_split: u32 = 0;
+                let mut x_split: u32 = 0;
+                let mut state = String::new();
+                for attr in e.attributes().flatten() {
+                    match attr.key.as_ref() {
+                        b"ySplit" => {
+                            y_split = String::from_utf8_lossy(&attr.value).parse().unwrap_or(0);
+                        }
+                        b"xSplit" => {
+                            x_split = String::from_utf8_lossy(&attr.value).parse().unwrap_or(0);
+                        }
+                        b"state" => {
+                            state = String::from_utf8_lossy(&attr.value).to_string();
+                        }
+                        _ => {}
+                    }
+                }
+                if state == "frozen" && (y_split > 0 || x_split > 0) {
+                    freeze_pane = Some((y_split, x_split));
+                }
+            }
             Ok(Event::Empty(ref e)) if in_cols && e.name().as_ref() == b"col" => {
                 let mut min: u32 = 0;
                 let mut max: u32 = 0;
@@ -658,6 +707,7 @@ fn parse_worksheet<R: Read + Seek>(
         merges,
         column_widths,
         row_heights,
+        freeze_pane,
     })
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -39,6 +39,9 @@ pub struct Sheet {
     pub column_widths: std::collections::HashMap<u32, f64>,
     /// Row heights: 0-based row index -> height in points.
     pub row_heights: std::collections::HashMap<u32, f64>,
+    /// Freeze pane split point: (rows_frozen, cols_frozen).
+    /// None if no freeze panes are set.
+    pub freeze_pane: Option<(u32, u32)>,
 }
 
 /// Convert an Excel serial number to (year, month, day, hour, minute, second, microsecond).

--- a/src/writer/xlsx.rs
+++ b/src/writer/xlsx.rs
@@ -69,6 +69,7 @@ pub struct StreamingXlsxWriter<W: Write + Seek> {
     pending_merges: PendingMerges,
     pending_columns: HashMap<u32, f64>,
     pending_row_heights: HashMap<u32, f64>,
+    pending_freeze_pane: Option<(u32, u32)>,
 }
 
 impl<W: Write + Seek> StreamingXlsxWriter<W> {
@@ -85,6 +86,7 @@ impl<W: Write + Seek> StreamingXlsxWriter<W> {
             pending_merges: PendingMerges { ranges: Vec::new() },
             pending_columns: HashMap::new(),
             pending_row_heights: HashMap::new(),
+            pending_freeze_pane: None,
         }
     }
 
@@ -128,6 +130,7 @@ impl<W: Write + Seek> StreamingXlsxWriter<W> {
         self.current_row = 0;
         self.sheet_open = true;
         self.sheet_data_started = false;
+        self.pending_freeze_pane = None;
         Ok(())
     }
 
@@ -136,6 +139,40 @@ impl<W: Write + Seek> StreamingXlsxWriter<W> {
     fn start_sheet_data(&mut self) -> Result<(), XlsxWriteError> {
         if self.sheet_data_started {
             return Ok(());
+        }
+
+        // Write <sheetViews> with freeze pane if set
+        if let Some((row_split, col_split)) = self.pending_freeze_pane.take() {
+            if row_split > 0 || col_split > 0 {
+                let top_left_cell = format!(
+                    "{}{}",
+                    col_index_to_letter(col_split as usize),
+                    row_split + 1
+                );
+                let active_pane = match (row_split > 0, col_split > 0) {
+                    (true, true) => "bottomRight",
+                    (true, false) => "bottomLeft",
+                    (false, true) => "topRight",
+                    (false, false) => unreachable!(),
+                };
+                write!(
+                    self.zip()?,
+                    "<sheetViews><sheetView tabSelected=\"1\" workbookViewId=\"0\">\
+                     <pane{}{}topLeftCell=\"{top_left_cell}\" activePane=\"{active_pane}\" state=\"frozen\"/>\
+                     <selection pane=\"{active_pane}\"/>\
+                     </sheetView></sheetViews>",
+                    if row_split > 0 {
+                        format!(" ySplit=\"{row_split}\"")
+                    } else {
+                        String::new()
+                    },
+                    if col_split > 0 {
+                        format!(" xSplit=\"{col_split}\"")
+                    } else {
+                        String::new()
+                    },
+                )?;
+            }
         }
 
         // Write <cols> if any column widths are set
@@ -297,6 +334,23 @@ impl<W: Write + Seek> StreamingXlsxWriter<W> {
             ));
         }
         self.pending_columns.insert(col_index, width);
+        Ok(())
+    }
+
+    /// Set freeze panes: freeze the top `row` rows and left `col` columns.
+    /// Must be called after add_sheet() but before write_row().
+    pub fn freeze_panes(&mut self, row: u32, col: u32) -> Result<(), XlsxWriteError> {
+        if !self.sheet_open {
+            return Err(XlsxWriteError::InvalidState(
+                "No sheet is open. Call add_sheet() first.".to_string(),
+            ));
+        }
+        if self.sheet_data_started {
+            return Err(XlsxWriteError::InvalidState(
+                "Freeze panes must be set before writing any rows.".to_string(),
+            ));
+        }
+        self.pending_freeze_pane = Some((row, col));
         Ok(())
     }
 
@@ -574,5 +628,91 @@ mod tests {
             CellValue::Bool(b) => assert!(*b),
             other => panic!("expected bool, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_freeze_panes_top_row() {
+        use crate::reader::xlsx::read_xlsx;
+        use std::io::Cursor;
+
+        let mut buf = Cursor::new(Vec::new());
+        {
+            let mut writer = StreamingXlsxWriter::new(&mut buf);
+            writer.add_sheet("Frozen").unwrap();
+            writer.freeze_panes(1, 0).unwrap();
+            writer
+                .write_row(&[CellValue::String("Header".to_string())])
+                .unwrap();
+            writer
+                .write_row(&[CellValue::String("Data".to_string())])
+                .unwrap();
+            writer.close().unwrap();
+        }
+
+        buf.set_position(0);
+        let sheets = read_xlsx(buf).unwrap();
+        assert_eq!(sheets[0].freeze_pane, Some((1, 0)));
+    }
+
+    #[test]
+    fn test_freeze_panes_left_column() {
+        use crate::reader::xlsx::read_xlsx;
+        use std::io::Cursor;
+
+        let mut buf = Cursor::new(Vec::new());
+        {
+            let mut writer = StreamingXlsxWriter::new(&mut buf);
+            writer.add_sheet("Frozen").unwrap();
+            writer.freeze_panes(0, 2).unwrap();
+            writer
+                .write_row(&[CellValue::String("A".to_string())])
+                .unwrap();
+            writer.close().unwrap();
+        }
+
+        buf.set_position(0);
+        let sheets = read_xlsx(buf).unwrap();
+        assert_eq!(sheets[0].freeze_pane, Some((0, 2)));
+    }
+
+    #[test]
+    fn test_freeze_panes_both() {
+        use crate::reader::xlsx::read_xlsx;
+        use std::io::Cursor;
+
+        let mut buf = Cursor::new(Vec::new());
+        {
+            let mut writer = StreamingXlsxWriter::new(&mut buf);
+            writer.add_sheet("Frozen").unwrap();
+            writer.freeze_panes(2, 1).unwrap();
+            writer
+                .write_row(&[CellValue::String("A".to_string())])
+                .unwrap();
+            writer.close().unwrap();
+        }
+
+        buf.set_position(0);
+        let sheets = read_xlsx(buf).unwrap();
+        assert_eq!(sheets[0].freeze_pane, Some((2, 1)));
+    }
+
+    #[test]
+    fn test_no_freeze_panes() {
+        use crate::reader::xlsx::read_xlsx;
+        use std::io::Cursor;
+
+        let mut buf = Cursor::new(Vec::new());
+        {
+            let mut writer = StreamingXlsxWriter::new(&mut buf);
+            writer.add_sheet("Plain").unwrap();
+            writer
+                .write_row(&[CellValue::String("Data".to_string())])
+                .unwrap();
+            writer.close().unwrap();
+        }
+
+        buf.set_position(0);
+        let sheets = read_xlsx(buf).unwrap();
+        assert_eq!(sheets[0].freeze_pane, None);
     }
 }

--- a/tests/test_xlsx_writer.py
+++ b/tests/test_xlsx_writer.py
@@ -467,3 +467,122 @@ def test_row_height_openpyxl_interop(tmp_xlsx):
     row_heights = sheets[0]["row_heights"]
     assert abs(row_heights[0] - 30.0) < 0.1  # Row 1
     assert abs(row_heights[1] - 50.0) < 0.1  # Row 2
+
+
+# --- Freeze panes ---
+
+
+def test_freeze_top_row(tmp_xlsx):
+    """Freeze the top row and verify roundtrip."""
+    with opensheet_core.XlsxWriter(tmp_xlsx) as w:
+        w.add_sheet("Frozen")
+        w.freeze_panes(row=1, col=0)
+        w.write_row(["Header1", "Header2"])
+        w.write_row(["Data1", "Data2"])
+
+    sheets = opensheet_core.read_xlsx(tmp_xlsx)
+    assert sheets[0]["freeze_pane"] == (1, 0)
+    assert sheets[0]["rows"][0] == ["Header1", "Header2"]
+
+
+def test_freeze_left_column(tmp_xlsx):
+    """Freeze the left column and verify roundtrip."""
+    with opensheet_core.XlsxWriter(tmp_xlsx) as w:
+        w.add_sheet("Frozen")
+        w.freeze_panes(row=0, col=1)
+        w.write_row(["Label", "Value"])
+
+    sheets = opensheet_core.read_xlsx(tmp_xlsx)
+    assert sheets[0]["freeze_pane"] == (0, 1)
+
+
+def test_freeze_both_row_and_column(tmp_xlsx):
+    """Freeze top 2 rows and left column."""
+    with opensheet_core.XlsxWriter(tmp_xlsx) as w:
+        w.add_sheet("Frozen")
+        w.freeze_panes(row=2, col=1)
+        w.write_row(["A", "B", "C"])
+        w.write_row(["D", "E", "F"])
+        w.write_row([1, 2, 3])
+
+    sheets = opensheet_core.read_xlsx(tmp_xlsx)
+    assert sheets[0]["freeze_pane"] == (2, 1)
+    assert sheets[0]["rows"][2] == [1, 2, 3]
+
+
+def test_no_freeze_pane(tmp_xlsx):
+    """Sheets without freeze panes return None."""
+    with opensheet_core.XlsxWriter(tmp_xlsx) as w:
+        w.add_sheet("Plain")
+        w.write_row(["no", "freeze"])
+
+    sheets = opensheet_core.read_xlsx(tmp_xlsx)
+    assert sheets[0]["freeze_pane"] is None
+
+
+def test_freeze_pane_multi_sheet(tmp_xlsx):
+    """Freeze panes are per-sheet."""
+    with opensheet_core.XlsxWriter(tmp_xlsx) as w:
+        w.add_sheet("Sheet1")
+        w.freeze_panes(row=1, col=0)
+        w.write_row(["Header"])
+        w.add_sheet("Sheet2")
+        w.write_row(["No freeze"])
+
+    sheets = opensheet_core.read_xlsx(tmp_xlsx)
+    assert sheets[0]["freeze_pane"] == (1, 0)
+    assert sheets[1]["freeze_pane"] is None
+
+
+def test_freeze_pane_after_write_row_raises(tmp_xlsx):
+    """Setting freeze panes after writing rows should raise an error."""
+    with pytest.raises(Exception, match="before writing any rows"):
+        with opensheet_core.XlsxWriter(tmp_xlsx) as w:
+            w.add_sheet("Fail")
+            w.write_row(["too late"])
+            w.freeze_panes(row=1, col=0)
+
+
+def test_freeze_pane_with_column_widths(tmp_xlsx):
+    """Freeze panes combined with column widths."""
+    with opensheet_core.XlsxWriter(tmp_xlsx) as w:
+        w.add_sheet("Both")
+        w.freeze_panes(row=1, col=0)
+        w.set_column_width("A", 20.0)
+        w.write_row(["Header"])
+        w.write_row(["Data"])
+
+    sheets = opensheet_core.read_xlsx(tmp_xlsx)
+    assert sheets[0]["freeze_pane"] == (1, 0)
+    assert sheets[0]["column_widths"][0] == 20.0
+
+
+def test_freeze_pane_openpyxl_interop(tmp_xlsx):
+    """Write freeze panes with openpyxl, read with opensheet_core."""
+    openpyxl = pytest.importorskip("openpyxl")
+
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.freeze_panes = "A2"  # Freeze top row
+    ws.append(["Header"])
+    ws.append(["Data"])
+    wb.save(tmp_xlsx)
+
+    sheets = opensheet_core.read_xlsx(tmp_xlsx)
+    assert sheets[0]["freeze_pane"] == (1, 0)
+
+
+def test_freeze_pane_openpyxl_both(tmp_xlsx):
+    """Write freeze panes (both row+col) with openpyxl, read with opensheet_core."""
+    openpyxl = pytest.importorskip("openpyxl")
+
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.freeze_panes = "B3"  # Freeze top 2 rows and left column
+    ws.append(["A", "B", "C"])
+    ws.append(["D", "E", "F"])
+    ws.append([1, 2, 3])
+    wb.save(tmp_xlsx)
+
+    sheets = opensheet_core.read_xlsx(tmp_xlsx)
+    assert sheets[0]["freeze_pane"] == (2, 1)


### PR DESCRIPTION
## Summary
- Added `freeze_panes(row, col)` method to `XlsxWriter` for freezing rows/columns
- Reader parses `<pane>` elements to extract freeze pane info from existing XLSX files
- `read_xlsx()` output now includes `"freeze_pane"` key (tuple or None) per sheet
- Supports top-row, left-column, and combined row+column freezing

## Test plan
- [x] 4 Rust unit tests (top row, left col, both, none)
- [x] 9 Python integration tests including:
  - Roundtrip write/read for all freeze scenarios
  - Multi-sheet with mixed freeze/no-freeze
  - Error when setting freeze after `write_row()`
  - Combined with column widths
  - openpyxl interop (both `A2` and `B3` freeze points)